### PR TITLE
Fix text log encoding

### DIFF
--- a/TrackerService/Client.cs
+++ b/TrackerService/Client.cs
@@ -78,7 +78,7 @@ public class Client {
 			StreamWriter logText = new(
 				$"logs/{imei} - {connectionTime:yyyy-MM-dd HH-mm-ss}.log",
 				true,
-				Encoding.ASCII
+				Encoding.UTF8
 			);
 
 			Console.WriteLine($"=== {imei} : {this._client.Client.RemoteEndPoint} ===");


### PR DESCRIPTION
Fixed the encoding in the text log, since it was displaying spaces as question marks
